### PR TITLE
Added TimeStamp approach for delay calculation

### DIFF
--- a/src/aqm-eval-suite/model/eval-topology.cc
+++ b/src/aqm-eval-suite/model/eval-topology.cc
@@ -20,7 +20,7 @@
  *          Mohit P. Tahiliani <tahiliani@nitk.edu.in>
  */
 
-#include "eval-topology.h"
+#include "ns3/log.h"
 #include "eval-ts.h"
 
 namespace ns3 {
@@ -148,9 +148,7 @@ EvaluationTopology::DestroyConnection ()
 void
 EvaluationTopology::PacketEnqueue (Ptr<const QueueDiscItem> item)
 {
-  Ptr<Packet> p = item->GetPacket ();
-  EvalTimestampTag tag;
-  p->AddPacketTag (tag);
+  NS_LOG_FUNCTION (this << item);
   Ptr<const Ipv4QueueDiscItem> iqdi = Ptr<const Ipv4QueueDiscItem> (dynamic_cast<const Ipv4QueueDiscItem *> (PeekPointer (item)));
   *m_enqueueTime->GetStream () << (iqdi->GetHeader ()).GetDestination ()
                                << " "
@@ -161,10 +159,7 @@ EvaluationTopology::PacketEnqueue (Ptr<const QueueDiscItem> item)
 void
 EvaluationTopology::PacketDequeue (Ptr<const QueueDiscItem> item)
 {
-  Ptr<Packet> p = item->GetPacket ();
-  EvalTimestampTag tag;
-  p->RemovePacketTag (tag);
-  Time delta = Simulator::Now () - tag.GetTxTime ();
+  Time delta = Simulator::Now () - item->GetTimeStamp ();
   if (m_lastQDrecord == Time::Min () || Simulator::Now () - m_lastQDrecord > MilliSeconds (10))
     {
       m_lastQDrecord = Simulator::Now ();


### PR DESCRIPTION
Removed the use of "EvalTimestampTag" class from AQM Evaluation Suite, and instead used the feature that is now available by default in ns-3's traffic control module to obtain the queue delay.