### PR TITLE
Fix error handling for invalid scenario names and numbers

### DIFF
--- a/src/aqm-eval-suite/examples/aqm-eval-suite-runner.cc
+++ b/src/aqm-eval-suite/examples/aqm-eval-suite-runner.cc
@@ -240,7 +240,7 @@ int main (int argc, char *argv[])
       if (!validScenarioName)
         {
           std::cout << "Error: Invalid scenario name \"" << scenarioName << "\"" << std::endl;
-          std::cout << "Valid scenario names are: \"All\", \"RttFairness\"";
+          std::cout << "Valid scenario names are: \"All\"";
           for (const auto& mapping : ScenarioNumberMapping)
             {
               std::cout << ", \"" << mapping.second << "\"";

--- a/src/aqm-eval-suite/examples/aqm-eval-suite-runner.cc
+++ b/src/aqm-eval-suite/examples/aqm-eval-suite-runner.cc
@@ -204,25 +204,65 @@ int main (int argc, char *argv[])
 
   if (scenarioName == "")
     {
-      scenarioName = ScenarioNumberMapping[scenarioNumber];
+      auto it = ScenarioNumberMapping.find (scenarioNumber);
+      
+      if (it != ScenarioNumberMapping.end ())
+        {
+          scenarioName = it->second;
+        }
+      else if (!scenarioNumber.empty ())
+        {
+          std::cout << "Error: Invalid scenario number \"" << scenarioNumber << "\"" << std::endl;
+          std::cout << "Valid scenario numbers are:";
+          for (const auto& mapping : ScenarioNumberMapping)
+            {
+              std::cout << " \"" << mapping.first << "\"";
+            }
+          std::cout << std::endl;
+          exit (-1);
+        }
     }
-
+    
+  // Check if scenarioName is valid (if it's not "All" or "RttFairness")
   if (scenarioName != "All" && scenarioName != "RttFairness")
     {
+      bool validScenarioName = false;
+      
+      for (const auto& mapping : ScenarioNumberMapping)
+        {
+          if (mapping.second == scenarioName)
+            {
+              validScenarioName = true;
+              break;
+            }
+        }
+        
+      if (!validScenarioName)
+        {
+          std::cout << "Error: Invalid scenario name \"" << scenarioName << "\"" << std::endl;
+          std::cout << "Valid scenario names are: \"All\", \"RttFairness\"";
+          for (const auto& mapping : ScenarioNumberMapping)
+            {
+              std::cout << ", \"" << mapping.second << "\"";
+            }
+          std::cout << std::endl;
+          exit (-1);
+        }
+      
       RunOneScenario (scenarioName);
     }
-  else if (scenarioName != "All" && scenarioName == "RttFairness")
+  else if (scenarioName == "RttFairness")
     {
       RunRttFairness (scenarioName);
     }
   else
     {
       RunRttFairness (scenarioName);
-      for (std::map<std::string, std::string>::iterator it = ScenarioNumberMapping.begin (); it != ScenarioNumberMapping.end (); ++it)
+      for (const auto& mapping : ScenarioNumberMapping)
         {
-          if (it->second != "RttFairness")
+          if (mapping.second != "RttFairness")
             {
-              RunOneScenario (it->second);
+              RunOneScenario (mapping.second);
             }
         }
     }


### PR DESCRIPTION
This pull request includes changes to improve error handling and validation for scenario names and numbers in the `src/aqm-eval-suite/examples/aqm-eval-suite-runner.cc` file. The most important changes include adding checks for invalid scenario numbers, providing user feedback for invalid inputs, and ensuring that scenario names are validated before execution.

Error handling improvements:

* Added a check to validate `scenarioNumber` and provide an error message if it is invalid, including a list of valid scenario numbers.
* Implemented a validation check for `scenarioName` to ensure it is either "All", "RttFairness", or a valid scenario name from the `ScenarioNumberMapping`. If invalid, an error message is displayed with a list of valid scenario names.

Code simplification:

* Replaced the iterator-based loop with a range-based for loop for better readability and modern C++ practices.

Example:

```bash
$ ./waf --run "aqm-eval-suite-runner --number=123"
Error: Invalid scenario number "123"
Valid scenario numbers are: "5.1.1" "5.1.2" "5.2" "5.3.1" "5.3.2" "5.4" "6" "8.2.2" "8.2.3" "8.2.4" "8.2.5" "8.2.6.1" "8.2.6.2"
Command ['/home/csc309/projects/ns-3-aqm-eval-suite/ns-3-dev-git/build/src/aqm-eval-suite/examples/ns3-dev-aqm-eval-suite-runner-debug', '--number=123'] exited with code 255
```

